### PR TITLE
Major rewrite to produce full parsable metadata.

### DIFF
--- a/iacrcc/METADATA.md
+++ b/iacrcc/METADATA.md
@@ -1,0 +1,166 @@
+# Metadata requirements
+
+The purpose of this document is to describe the metadata requirements
+for a new journal (as of 2021). Conferences are outside the scope of
+this discussion.  The primary purpose of metadata is to facilitate
+browsing, search, and bibliometrics. Bibliometrics is primarily
+concerned with classification, indexing, and ranking of articles,
+authors, journals, institutions, etc.  An example is the REF (Research
+Excellence Framework) in the UK that is used to assess the quality of
+research, and allocate funding accordingly. A lot of the academic
+reputation of an author, article, institution, or journal flows from
+statistics about how they are cited, and for this purpose it is
+important to have unique identifiers on these entities, and to identify
+the entities correctly at the time of publication.
+
+The publication of metadata is carried out through different workflows,
+including crawling by consumers, reporting by the journal to indexing agencies,
+and archiving. There is no single schema that works for everyone, but we
+should be able to capture the raw elements that can be used in the different
+workflows. As an example, when a DOI is registered,
+There are multiple consumers of metadata about publications, and there
+are multiple agencies that assign unique identifiers. 
+
+## Recommendations:
+For the TL;DR crowd, this section summarizes recommendations.
+
+1. We should strongly recommend that author names are written in full as they appear on
+   previous papers. If an author has used a middle initial, it should be included.
+2. We should strongly recommend that authors include their ORCID ID. They are not required.
+   A coauthor's ORCID ID can be found by searching at https://orcid.org/
+3. We should strongly recommend that authors include the ROR ID of their affiliations. They
+   can be found at https://ror.org/search
+4. We should strongly recommend that authors include canonicalized institution names. As an
+   example, University of Southern California is preferred to just USC, since the latter
+   could be University of South Carolina.
+5. Authors may specify author names in UTF-8 or TeX codes. They will be translated to UTF-8.
+6. Titles and abstracts may include mathematics through the use of TeX. As of now, crossref
+   accepts both TeX and MathML, but MathML may be preferred for export. Luckily there is a
+   converter: [latex2mathml](https://pypi.org/project/latex2mathml/).
+
+The list of metadata fields is as follows:
+1. title
+2. abstract
+3. a list of affiliations (without duplicates). Each one should have
+   - full name
+   - ROR ID (optional)
+   - department (optional)
+   - country
+3. a list of authors, in order determined by the authors themselves. There is no notion of
+   corresponding author in the paper itself. Each author should have:
+   - full name as usually written on previous publications by the author. (required)
+   - surname (required)
+   - affiliation indices (required, written as {1,3} to indicate which in the list of
+     affiliations applies to that author.
+   - ORCID ID (optional)
+4. funding agencies (TBD). See [below](#grants)
+5. bibliographic references. These will be extracted from the submitted BibTeX file. Each
+   one should contain necessary fields in a BibTeX entry, but also:
+   - DOI (optional, but strongly urged)
+   - URL (optional)   
+
+## Identifier Namespaces
+Unique identifiers are typically associated with the following:
+
+* journal: Most commonly the ISSN (International Standard Serial Number). These have
+  two types for print and electronic  media. ISBN is assigned to books rather than
+  journals. Various disciplines also use identifiers that are unique to their
+  discipline (e.g., pubmed). Journals may be issued a DOI, but this is rare.
+* journal volume and/or issue. These are ad hoc, and are dependent on the publisher.
+  They used to reflect a bound periodical.
+* article: these are now assigned DOIs. These are segmented, and a prefix is generally assigned
+  to a journal which then assigns DOIs within their prefix.
+* author: names are inadequate (they aren't unique and they can change).
+  - ORCID IDs are relatively recent, but are rapidly gaining traction.
+  - Clarivate assigns their own [ResearcherID](http://www.researcherid.com/#rid-for-researchers)
+  - Scopus assigns their own [identifier](https://www.scopus.com/authid/detail.uri?authorId=7004055156)
+  - arXiv also assigns a [unique ID](https://arxiv.org/help/author_identifiers) to authors, but
+    those are intended only for tracking within arXiv.
+* affiliation: 
+  - ROR IDs ([Research Organization Registry](https://ror.org/)) identifies institutions at
+    roughly the level of a university but not a department. ROR is a community effort organized
+    by Crossref, the California Digital Library,  Datacite,
+    [Digital science](https://www.digital-science.com/), and is led by a steering group. They have
+    explicitly decided not to identify departments within institutions, which leaves a hole because
+    some indexing agencies want to rate computer science departments against each other. This is
+    difficult because some are joint with mathematics or informatics or EE, and some have sub-departments (e.g. CSAIL and LIDS at MIT)
+  - GRID ID (now replaced by ROR)
+  - ISNI (International Standard Name Identifier). Started by ISO. Seems irrelevant now.
+  - Crossref assigns funding ids to organizations, which could be
+    [grant agencies](https://api.crossref.org/funders/100000001) or employers
+    like [universities](https://api.crossref.org/funders/501100000765).
+  - Scopus assigns an [AF-ID](https://service.elsevier.com/app/answers/detail/a_id/11215/supporthub/scopus/) to affiliations of authors. So does Clarivate.
+  - Wikidata (e.g., [IBM](https://www.wikidata.org/wiki/Q37156)). Note that Wikidata assigns
+    IDs at a finer level than ROR: [CSAIL](https://www.wikidata.org/wiki/Q1354917) or
+    [IBM Research](https://www.wikidata.org/wiki/Q3146518) under IBM.
+* funding sources:
+    This is the most vague, and will be deferred for now. The most promising advance in this area
+    is the [Open Funder Registry](https://www.crossref.org/services/funder-registry/) but that
+    data is distributed by an old-style RDF file. This is apparently used by Scopus.
+    Funding organizations tend to have hierarchical organization, as in
+    - National Science Foundation (NSF)
+      - Computer and Information Science and Engineering (CISE)
+        - Division of Computing and Communication Foundations (CCF)
+          - Cyberinfrastructure for Sustained Scientific Innovation (CSSI)
+    Within these organizations, grants may also be assigned an identifier. Exactly how a funding
+    agency gets cited varies from one to another. A document from ORCID
+    [surveyed this topic](https://info.orcid.org/wp-content/uploads/2021/01/20161031-OrgIDProviderSurvey.pdf) in 2016, and listed the following:
+    * Open Funder Registry (crossref?) See [CISE](https://api.crossref.org/funders/100000083) which
+      is identified by 100000083. This seems most viable.
+    * ISNI
+    * Ringgold
+    * Publisher Solutions International
+    * GRID
+    * LEI
+    * OrgRef
+    
+       
+## DOI creations
+
+DOIs are issued by agencies delegated by doi.org. Two prominent
+agencies are
+[datacite](https://support.datacite.org/docs/api-create-dois) and
+crossref.
+
+## Indexing agencies
+
+There are a large number of agencies who collect and organize
+bibliographic information. Some of them are community-driven (e.g.,
+crossref.org), and some are proprietary (e.g., Google and
+Scopus). Funding agencies and research institutions also like to keep track
+of what their organizations have contributed to, so that they can gain support from
+taxpayers or stockholders. This section will summarize what I see as some of the most
+important indexing agencies, but this list may change over time.
+
+### Google Scholar
+
+### crossref.org
+Crossref maintains an [api](https://www.crossref.org/documentation/content-registration/) for
+DOI assignment.
+
+### Datacite
+They publish a [schema](https://schema.datacite.org/) for metadata.
+
+### DOAJ
+
+### DBLP (computer science only)
+
+### JATS
+
+### Openaire
+
+### Sherpa Romeo
+
+### OpenDOAR
+
+### Scopus (Elsevier)
+
+### ISI Web of Science (clarivate)
+
+## Export formats
+
+### JATS
+### meta tags in html files
+### PDF metadata
+### XML Formats
+

--- a/iacrcc/README.md
+++ b/iacrcc/README.md
@@ -2,29 +2,30 @@
 
 ## 🔧 This is a work in progress 🔧
 
-This directory contains a LaTeX cls file for the new IACR
-Communications on Cryptology journal.  The user documentation is
-contained in example.tex, and this README currently holds only
-development details.
+This directory contains `iacrcc.cls` and `iacrcc.bst` for processing
+of articles submitted to the new IACR Communications on Cryptology
+journal.  The user documentation is contained in example.tex, and this
+README currently holds only development details. 
 
 The purpose of this style is to facilitate proper capture of author metadata
 for the publication editing workflow. Typically a LaTeX class is concerned with
 only the layout of the document, but we have added some additional requirements:
-1. when the user runs pdflatex on their document, it should produce a parsable text
-   file that contains structured metadata about the paper, including title, authors,
-   their affiliations, and the paper citations.
+1. when the user runs pdflatex/bibtex/pdflatex on their document, it
+   should produce a parsable text file that contains structured metadata about
+   the paper, including title, authors, their affiliations, and the paper citations.
 2. the author should only have to enter this metadata once, in properly formatted
    LaTeX macros that conform to the required cls.
 
 This LaTeX style is based on the previous [iacrtrans](https://github.com/Cryptosaurus/iacrtrans)
 class used to ToSC and TCHES. These may be unified in the future.
 
-While the file we generate appears to be `yaml`, it's not guaranteed
-to be parsable as a `yaml` file because of special characters like {
-or \ or ". For this reason we use a custom parser that looks only at
-the tags on the line to decide what the structure is. The format of
-the file is hierarchical, and is perhaps best illustrated with an
-example in which there are three authors show share three affiliations.
+We perhaps could have written the `.meta` file as `yaml`, but this is
+problematic because of special characters like { or \ or ". For this
+reason we use a custom parser that looks only at the tags on the line
+to decide what the structure is. The format of the file is
+hierarchical, and is perhaps best illustrated with an example in which
+there are three authors who share three affiliations on a paper with
+two references.
 
 ```
 title: How to break {RSA} digital signatures
@@ -41,26 +42,55 @@ author:
   inst: 1,3
   orcid: xxxx-yyyy-zzzz-wwww
   email: len@usc.edu
-affil:
+affililation:
   name: MIT
   ror: ljl2j543
-affil:
+affiliation:
   name: Weizmann Institute
-affil:
+affiliation:
   name: University of Southern California
   ror: 2342342xy
-citation:
+citation: article
   title: The best algorithm never exists
   authors: Alfred Alliant and David Dumbo
+  author: Alfred Alliant
+  surname: Alliant
+  author: David Dumbo
+  surname: Dumbo
+  journal: Journal of Craptology
   doi: 10.1007/2122_133
-citation:
+citation: book
   title: Is it funny if you have to explain it?
   authors: Ralph Bunch and Ida Lupino
+  author: Ralph Bunch
+  surname: Bunch
+  author: Ida Lupino
+  surname: Lupino
+  year: 1992
+  publisher: Marvel Comics
 ```
-The specification of metadata requirements is hopefully readily apparent
-from this example. The structure is designed to fulfill the requirements
-for consumers of metadata about papers, which is described in a
-[separate document](METADATA.md).
+The specification of metadata requirements is hopefully readily
+apparent from this example. In citations, authors are listed on one
+string, but then each author is listed separately along with their
+surname.  Due to the fact that LaTeX has trouble producing UTF-8,
+names are encoded using TeX codes for accents. The structure is
+designed to fulfill the requirements for consumers of metadata about
+papers, which is described in a [separate document](METADATA.md).
+
+## Production of metadata.
+
+Note that both `iacrcc.cls` and `iacrcc.bst` are required to be used,
+since they work together.  Authors supply their metadata in LaTeX
+macros using macros from `iacrcc.cls`. When the author runs `pdflatex
+main` on the file `main.tex`, it produces an output `main.meta` that
+contains the metadata above, but without the citation fields. When the
+author then runs `bibtex main` using `iacrcc.bst`, it produces a
+`main.bbl` file that contains extra LaTeX macros to write citation
+metadata. When the author runs `pdflatex main` a second time, it
+includes the `main.bbl` file to produce the bibliography, but now it
+also runs macros to write the citation metadata into `main.meta`. This
+is similar to how the `hyperref` package works, by writing a file
+`main.out` with bookmark commands.
 
 ## Related work
 

--- a/iacrcc/biblio.bib
+++ b/iacrcc/biblio.bib
@@ -1,7 +1,178 @@
+% Some of these are copied from cryptobib.
 @manual{AES-FIPS,
   key           = {NIST},
   organization  = {{National Institute of Standards and Technology}},
   title         = {Announcing the {Advanced Encryption Standard} ({AES})},
   year          = {2001},
   note          = {Federal Information Processing Standards Publication 197, \url{http://csrc.nist.gov/publications/fips/fips197/fips-197.pdf}},
+}
+
+@Misc{AES,
+  key =          "AES",
+  title =        "{Advanced} {Encryption} {Standard} ({AES})",
+  year =         2001,
+  month =        nov,
+  howpublished = "National Institute of Standards and Technology (NIST),
+                  {FIPS PUB} 197, {U.S.} Department of Commerce",
+}
+
+@INPROCEEDINGS{EC:Matsui93,
+  author =       "Mitsuru Matsui",
+  title =        "Linear Cryptanalysis Method for {DES} Cipher",
+  pages =        "386--397",
+  editor =       eurocrypt93ed,
+  booktitle =    eurocrypt93name,
+  volume =       eurocrypt93vol,
+  address =      eurocrypt93addr,
+  month =        eurocrypt93month,
+  publisher =    eurocryptpub,
+  series =       mylncs,
+  year =         1994,
+  doi =          "10.1007/3-540-48285-7_33",
+}
+
+@Article{JC:BihSha91,
+  author =       "Eli Biham and
+                  Adi Shamir",
+  title =        "Differential Cryptanalysis of {DES}-like Cryptosystems",
+  pages =        "3--72",
+  volume =       4,
+  month =        jan,
+  publisher =    springer,
+  year =         1991,
+  journal =      jcrypto,
+  number =       1,
+  doi =          "10.1007/BF00630563",
+}
+
+@InProceedings{C:KocJafJun99,
+  author =       "Paul C. Kocher and
+                  Joshua Jaffe and
+                  Benjamin Jun",
+  title =        "Differential Power Analysis",
+  pages =        "388--397",
+  editor =       crypto99ed,
+  booktitle =    crypto99name,
+  volume =       crypto99vol,
+  address =      cryptoaddr,
+  month =        crypto99month,
+  publisher =    cryptopub,
+  series =       mylncs,
+  year =         1999,
+  doi =          "10.1007/3-540-48405-1_25",
+}
+
+@Book{Dalheimer02,
+  author =       "Matthias Kalle Dalheimer",
+  title =        "Programming With {Qt}, Second Edition: Writing Portable {GUI} applications on {UNIX} and {Win32}",
+  publisher =    "O'Reilly \& Associates, Inc.",
+  month =        mar,
+  year =         2002
+}
+
+@InProceedings{ACISP:MurPla19,
+  author =       "Sean Murphy and
+                  Rachel Player",
+  title =        "{$\delta$}-subgaussian Random Variables in Cryptography",
+  pages =        "251--268",
+  editor =       acisp19ed,
+  booktitle =    acisp19name,
+  volume =       acisp19vol,
+  address =      acisp19addr,
+  month =        acisp19month,
+  publisher =    acisppub,
+  series =       mylncs,
+  year =         2019,
+  doi =          "10.1007/978-3-030-21548-4_14",
+}
+
+@InProceedings{ACISP:LYLF19,
+  author =       "Weixuan Li and
+                  Wei Yu and
+                  Bao Li and
+                  Xuejun Fan",
+  title =        "Speeding up Scalar Multiplication on {Koblitz} Curves Using {$\mu_4$} Coordinates",
+  pages =        "620--629",
+  editor =       acisp19ed,
+  booktitle =    acisp19name,
+  volume =       acisp19vol,
+  address =      acisp19addr,
+  month =        acisp19month,
+  publisher =    acisppub,
+  series =       mylncs,
+  year =         2019,
+  doi =          "10.1007/978-3-030-21548-4_34",
+}
+
+@Book{Bohme10,
+  author =       "Rainer B{\"o}hme",
+  title =        "Advanced Statistical Steganalysis",
+  publisher =    springer,
+  series =       myisc,
+  year =         2010,
+  doi =          "10.1007/978-3-642-14313-7",
+  isbn =         "978-3-642-14312-0",
+}
+
+@InProceedings{ACISP:WeiSteSha03,
+  author =       "Andr{\'e} Weimerskirch and
+                  Douglas Stebila and
+                  Sheueling Chang Shantz",
+  title =        "Generic {$\text{GF}(2^m)$} Arithmetic in Software and Its Application to {ECC}",
+  pages =        "79--92",
+  editor =       acisp03ed,
+  booktitle =    acisp03name,
+  volume =       acisp03vol,
+  address =      acisp03addr,
+  month =        acisp03month,
+  publisher =    acisppub,
+  series =       mylncs,
+  year =         2003,
+  doi =          "10.1007/3-540-45067-X_8",
+}
+
+@InProceedings{CCS:BHKNRS19,
+  author =       "Daniel J. Bernstein and
+                  Andreas H{\"u}lsing and
+                  Stefan K{\"o}lbl and
+                  Ruben Niederhagen and
+                  Joost Rijneveld and
+                  Peter Schwabe",
+  title =        "The {SPHINCS}{$^+$} Signature Framework",
+  pages =        "2129--2146",
+  editor =       ccs19ed,
+  booktitle =    ccs19name,
+  address =      ccs19addr,
+  month =        ccs19month,
+  publisher =    ccspub,
+  year =         2019,
+  doi =          "10.1145/3319535.3363229",
+}
+
+@InProceedings{ACNS:DurHugVau20,
+  author =       "F. Bet{\"u}l Durak and
+                  Lo{\"i}s {Huguenin-Dumittan} and
+                  Serge Vaudenay",
+  title =        "{$\mathsf{BioLocker}$}: {A} Practical Biometric Authentication Mechanism Based on {3D} Fingervein",
+  pages =        "62--80",
+  editor =       acns20ed,
+  booktitle =    acns20name2,
+  volume =       acns20vol2,
+  address =      acns20addr,
+  month =        acns20month,
+  publisher =    acnspub,
+  series =       mylncs,
+  year =         2020,
+  doi =          "10.1007/978-3-030-57878-7_4",
+}
+
+@ARTICLE{vonNeumann,
+  author={von Neumann, John},
+  journal={Annals of the History of Computing}, 
+  title={The Principles of Large-Scale Computing Machines}, 
+  year={1981},
+  volume={3},
+  number={3},
+  pages={263-273},
+  doi={10.1109/MAHC.1981.10025}
 }

--- a/iacrcc/example.tex
+++ b/iacrcc/example.tex
@@ -10,10 +10,9 @@
 % - Add "spthm" for LNCS-like theorems
 
 \errorcontextlines=5
-
+\newcommand\niceguy{Ron Rivest}
 %%%% 2. PACKAGES %%%%
 \usepackage{lipsum} % Example package -- can be removed
-
 
 %%%% 3. AUTHOR, INSTITUTE %%%%
 
@@ -23,8 +22,10 @@
 \author[orcid=0000-0003-1010-8157,inst={1,2}]{Alice Accomplished}
 % NOTE: Only one affiliation for this author.
 \author[inst={1},footnote={Thanks to my mom!}]{Bob Badenuff}
+\author[inst={3,2,1}]{Tancr{\`e}de LePoint}
 \affiliation[ror=02t274463]{University of California, Santa Barbara}
 \affiliation{University of Second Choice}
+\affiliation{Bo{\u g}azi{\c c}i University}
 
 \genericfootnote{This is the full-version of our previous work.}
 
@@ -35,6 +36,8 @@
 \author{Bob Badenuff
   \affiliation{1}
   \sponsor{1}}
+\author{Tancr{\`e}de LePoint
+  \affiliation{2,1}}
 \affiliation{University of California, Santa Barbara\department{Department of Computer Science}\RORID{02t274463}}
 \affiliation{University of Second Choice}
 
@@ -53,15 +56,15 @@
 % Note that \thanks and \footnote are forbidden in \title. Please use
 % \genericfootnote.
 \title[Thoughts on binary functions]{Thoughts about
-"binary" functions on $GF(p)$}
+"binary" functions on $GF(p)$ by \niceguy}
 \begin{document}
 
 \maketitle
 
-
 %%%% 5. ABSTRACT %%%%
 \begin{abstract}
-  In this paper we prove that the One-Time-Pad has perfect security.
+  In this paper we prove that the One-Time-Pad has perfect security, unless you use
+  double encryption with {$\mathsf{SingleKey}$}.
 
   \lipsum[8]
 \end{abstract}
@@ -75,7 +78,12 @@ security, and can be analysed with linear
 cryptanalysis~\cite{EC:Matsui93}, differential
 cryptanalysis~\cite{JC:BihSha91}, or differential power
 analysis~\cite{C:KocJafJun99}.  We show that the One-Time-Pad is
-unconditionally secure in \autoref{sec:main}.
+unconditionally secure in \autoref{sec:main}. Let's not forget
+the work by John~\cite{vonNeumann}.
+
+Note that we can tolerate ampersands~\cite{Dalheimer02} and \TeX
+character codes~\cite{Bohme10} and math in
+title~\cite{ACISP:MurPla19,ACISP:LYLF19,ACISP:WeiSteSha03,CCS:BHKNRS19,ACNS:DurHugVau20}.
 
 \lipsum[9]
 
@@ -83,14 +91,17 @@ unconditionally secure in \autoref{sec:main}.
 
 \lipsum
 
+\section{This has $a=b$}
+\lipsum
+
 This\footnote{is a footnote}.
 
 %%%% 8. BILBIOGRAPHY %%%%
 \bibliographystyle{iacrcc}
-\bibliography{cryptobib/abbrev3,cryptobib/crypto,biblio}
+\bibliography{cryptobib/abbrev3,biblio}
 %%%% NOTES
 % - Download abbrev3.bib and crypto.bib from https://cryptobib.di.ens.fr/
-% - Use bilbio.bib for additional references not in the cryptobib database.
+% - Use biblio.bib for additional references not in the cryptobib database.
 %   If possible, take them from DBLP.
 
 \end{document}

--- a/iacrcc/iacrcc.bst
+++ b/iacrcc/iacrcc.bst
@@ -85,7 +85,7 @@ FUNCTION {init.state.consts}
   #3 'after.block :=
 }
 
-STRINGS { s t }
+STRINGS { s t surname fullname }
 
 FUNCTION {output.nonnull}
 { 's :=
@@ -303,45 +303,168 @@ FUNCTION {format.title}
   if$
 }
 
-%% This function generates a string to report metadata about the paper.
-FUNCTION {format.meta}
+INTEGERS { l }
+FUNCTION {string.length}
 {
-  title empty$
-  { "\iacrbib{}{" }
-  { "\iacrbib{" title * "}{" * }
+  #1 'l :=
+  {duplicate$ duplicate$ #1 l substring$ = not}
+    {l #1 + 'l :=}
+  while$
+  pop$ l
+}
+
+STRINGS { replace find text }
+INTEGERS { find_length }
+
+% usage: <string> "_" "\textunderscore" find.replace
+% FUNCTION {find.replace}
+% { 'replace :=
+%   'find :=
+%   'text :=
+%   find string.length 'find_length :=
+%   ""
+%     { text empty$ not }
+%     { text #1 find_length substring$ find =
+%         {
+%           replace *
+%           text #1 find_length + global.max$ substring$ 'text :=
+%         }
+%         { text #1 #1 substring$ *
+%           text #2 global.max$ substring$ 'text :=
+%         }
+%       if$
+%     }
+%   while$
+% }
+
+FUNCTION {meta.names}
+{'s :=
+  #1 'nameptr :=
+  s num.names$ 'numnames :=
+  numnames 'namesleft :=
+    { namesleft #0 > }
+    {  s nameptr "{ff }{vv }{ll}" format.name$ 'fullname :=
+      "\writemeta{author}{" fullname * "}" * write$ newline$
+      s nameptr "{vv }{ll}" format.name$ 'surname :=
+      "\writemeta{surname}{" surname * "}" * write$ newline$
+      nameptr #1 + 'nameptr :=
+      namesleft #1 - 'namesleft :=
+    }
+  while$
+}
+
+% Output commands to write fields into the meta file.
+FUNCTION {meta.all}
+{
+  author empty$
+    { "\iacrmetacite{" type$ "l" change.case$ * "}{" * cite$ * "}{}" * }
+    { "\iacrmetacite{" type$ "l" change.case$ * "}{" * cite$ * "}{" * author * "}" * }
   if$
-    author empty$
-    { "}{" * }
-    { author * "}{" * }
-    if$
-    doi empty$
-    { "}" * }
-    { doi * "}" * }
-    if$
-}
-
-FUNCTION {comment.title}
-{
- title empty$
-    { "" }
-    { "%%TITLE:" title * }
- if$
-}
-
-FUNCTION {comment.doi}
-{
- doi empty$
-    { "" }
-    { "%%DOI:" doi * }
- if$
-}
-
-FUNCTION {comment.author}
-{
- author empty$
-    { "" }
-    { "%%AUTHORS:" author * }
- if$
+  write$ newline$
+  author missing$
+    { }
+    { author meta.names }
+  if$
+  address missing$
+    { }
+    { "\writemeta{address}{" address * "}" * write$ newline$ }
+  if$
+  booktitle missing$
+    { }
+    { "\writemeta{booktitle}{" booktitle * "}" * write$ newline$ }
+  if$
+  chapter missing$
+    { }
+    { "\writemeta{chapter}{" chapter * "}" * write$ newline$ }
+  if$
+  doi missing$
+    { }
+    { "\writemeta{doi}{" doi * "}" * write$ newline$ }
+  if$
+  eid missing$
+    { }
+    { "\writemeta{eid}{" eid * "}" * write$ newline$}
+  if$
+  edition missing$
+    { }
+    { "\writemeta{edition}{" edition * "}" * write$ newline$ }
+  if$
+  editor missing$
+    { }
+    { "\writemeta{editor}{" editor * "}" * write$ newline$ }
+  if$
+  howpublished missing$
+    { }
+    { "\writemeta{howpublished}{" howpublished * "}" * write$ newline$ }
+  if$
+  institution missing$
+    { }
+    { "\writemeta{institution}{" institution * "}" * write$ newline$ }
+  if$
+  isbn missing$
+    { }
+    { "\writemeta{isbn}{" isbn * "}" * write$ newline$ }
+  if$
+  issn missing$
+    { }
+    { "\writemeta{issn}{" issn * "}" * write$ newline$ }
+  if$
+  journal missing$
+    { }
+    { "\writemeta{journal}{" journal * "}" * write$ newline$ }
+  if$
+  key missing$
+    { }
+    { "\writemeta{key}{" key * "}" * write$ newline$ }
+  if$
+  month missing$
+    { }
+    { "\writemeta{month}{" month * "}" * write$ newline$ }
+  if$
+  note missing$
+    { }
+    { "\writemeta{note}{" note * "}" * write$ newline$ }
+  if$
+  number missing$
+    { }
+    { "\writemeta{number}{" number * "}" * write$ newline$ }
+  if$
+  organization missing$
+    { }
+    { "\writemeta{organization}{" organization * "}" * write$ newline$ }
+  if$
+  pages missing$
+    { }
+    { "\writemeta{pages}{" pages * "}" * write$ newline$ }
+  if$
+  publisher missing$
+    { }
+    { "\writemeta{publisher}{" publisher * "}" * write$ newline$ }
+  if$
+  school missing$
+    { }
+    { "\writemeta{school}{" school * "}" * write$ newline$ }
+  if$
+  series missing$
+    { }
+    { "\writemeta{series}{" series * "}" * write$ newline$ }
+  if$
+  title missing$
+    { }
+    { "\writemeta{title}{" title * "}" * write$ newline$ }
+  if$
+  url missing$
+    { }
+    { "\writemeta{url}{" url * "}" * write$ newline$ }
+  if$
+  volume missing$
+    { }
+    { "\writemeta{volume}{" volume * "}" * write$ newline$ }
+  if$
+  year missing$
+    { }
+    { "\writemeta{year}{" year * "}" * write$ newline$ }
+  if$
 }
 
 FUNCTION {format.full.names}
@@ -416,6 +539,7 @@ FUNCTION {make.full.names}
 
 FUNCTION {output.bibitem}
 { newline$
+  meta.all newline$
   "\bibitem[" write$
   label write$
   ")" make.full.names duplicate$ short.list =
@@ -426,11 +550,7 @@ FUNCTION {output.bibitem}
   cite$ write$
   "}" write$
   newline$
-  format.meta write$ newline$
   ""
-  comment.title write$ newline$
-  comment.doi write$ newline$
-  comment.author write$ newline$
   before.all 'output.state :=
 }
 
@@ -1453,16 +1573,27 @@ FUNCTION {begin.bib}
     'skip$
     { preamble$ write$ newline$ }
   if$
-    
   "\begin{thebibliography}{" number.label int.to.str$ * "}" *
   write$ newline$
-  "\providecommand{\iacrbib}[3]{\immediate\write\meta{citation:}%"
+  "\newcommand{\writemeta}[2]{%"
   write$ newline$
-  "\immediate\write\meta{\IACRSS title: #1}%"
+  "\ifstrempty{#2}{}{\immediate\write\meta{\IACRSS #1: \unexpanded{#2}}}}"
   write$ newline$
-  "\ifstrempty{#2}{}{\immediate\write\meta{\IACRSS authors: #2}}%"
+  "\newcommand{\iacrmetacite}[3]{\immediate\write\meta{citation: #1 #2}%"
   write$ newline$
-  "\ifstrempty{#3}{}{\immediate\write\meta{\IACRSS doi: #3}}}"
+  "\ifstrempty{#3}{}{\immediate\write\meta{\IACRSS authors: \detokenize{#3}}}}"
+  write$ newline$
+  "\newcommand{\iacrbib}[5]{\immediate\write\meta{citation:}%"
+  write$ newline$
+  "\immediate\write\meta{\IACRSS type: #1}%"
+  write$ newline$
+  "\immediate\write\meta{\IACRSS title: \detokenize{#2}}%"
+  write$ newline$
+  "\ifstrempty{#3}{}{\immediate\write\meta{\IACRSS authors: \detokenize{#3}}}%"
+  write$ newline$
+  "\ifstrempty{#4}{}{\immediate\write\meta{\IACRSS doi: #4}}"
+  write$ newline$
+  "\ifstrempty{#5}{}{\immediate\write\meta{\IACRSS journal: #5}}}"
   write$ newline$
   "\providecommand{\natexlab}[1]{#1}"
   write$ newline$

--- a/iacrcc/iacrcc.cls
+++ b/iacrcc/iacrcc.cls
@@ -340,7 +340,7 @@
   % Write out the author in the meta file.
   \immediate\write\meta{author:}%
   % name is indented by two spaces.
-  \immediate\write\meta{\IACRSS name: #2}%
+  \immediate\write\meta{\IACRSS name: \unexpanded{#2}}%
   \ifstrempty{#1}{%
     \ifx\@author\@empty
       \gdef\@author{#2}%
@@ -390,10 +390,8 @@
 
 \renewcommand\affiliation[2][]{%
   \global\advance\num@affil by 1\relax%
-  \ifnum\num@affil=1\relax
     \immediate\write\meta{affiliation:}%
-  \fi
-  \immediate\write\meta{\IACRSS name: #2}%
+  \immediate\write\meta{\IACRSS name: \unexpanded{#2}}%
   %  
   \ifx\@affiliation\@empty
     \gdef\@affiliation{#2}%


### PR DESCRIPTION
This modifies iacrcc.cls and iacrcc.bst to produce metadata in a parseable format. The format and procedure is described in METADATA.md. The strategy is slightly indirect, but is an ordinary latex compilation:
1. run `pdflatex example` to produce `example.aux` file with references.
2. run `bibtex example` to produce `example.bbl` with latex commands to produce metadata. This uses `iacrcc.bst`
3. run `pdflatex example` to process latex commands in `example.bbl` and produce `example.meta`
4. run `pdflatex example` one final time to resolve references.

example.tex has more citations to produce a realistic test.

There are a bunch of open issues associated with this, including the fact that it needs more testing and the output still contains LaTeX macros in the title and author names. If we use xelatex or lualatex we might be able to write things like \'e in UTF-8 instead of as TeX codes.