### PR TITLE
Add plaintext argument

### DIFF
--- a/iacrcc/iacrcc.cls
+++ b/iacrcc/iacrcc.cls
@@ -1,5 +1,5 @@
-\def\fileversion{0.23}
-\def\filedate{2023/03/02}
+\def\fileversion{0.24}
+\def\filedate{2023/03/24}
 
 \NeedsTeXFormat{LaTeX2e}[1995/12/01]
 \typeout{^^J  ***  LaTeX class for IACR Communications in Cryptology v\fileversion\space ***^^J}
@@ -305,14 +305,12 @@ xscale=\@OrigHeightRecip*\@curXheight,transform shape]
   running/.initial=\@empty,
   onclick/.initial=\@empty,
   subtitle/.initial=\@empty,
+  plaintext/.initial={},
 }
 \def\IACR@title@params@set@keys#1{%
   \pgfkeys{/IACR-title/entities/.cd,#1}}
 \def\IACR@title@params@get#1{%%
   \pgfkeysvalueof{/IACR-title/entities/#1}}
-\newcommand\IACR@title@params@clearkeys{%
-  \IACR@title@params@set@keys{running=\@empty,onclick=\@empty,subtitle=\@empty}%
-}
 
 \pgfkeys{/IACR-funding/entities/.cd,
   country/.initial=\@empty,
@@ -384,6 +382,9 @@ xscale=\@OrigHeightRecip*\@curXheight,transform shape]
       \ClassError{iacrcc}{An abstract with abstract environment is required}{}%
     }%
   }{}%
+  % This detects \usepackage[T1]{fontenc}
+  \ltx@iffileloaded{t1lmr.fd}{%
+    \ClassWarningNoLine{iacrcc}{^^J--------------------------------------------^^JThe T1 encoding will cause problems in production. Do not use it}}{}
 }
 
 \let\storeprotect\protect
@@ -653,6 +654,68 @@ xscale=\@OrigHeightRecip*\@curXheight,transform shape]
   \IACR@funding@params@clearkeys%
 }
  
+% This is a complicated implmentation to test whether a token list is
+% appropriate to use as metadata. It is intended to make sure that
+% \write will produce a string without macros, except that macros are
+% allowed in math mode. In a previous implementation we compared the argument
+% to \text_purify:n applied to the argument, but this did not allow accents
+% to be applied. This implmentation is based on tokcycle, which
+% provides handlers for four classes of tokens: character, group,
+% macro, and space.
+\RequirePackage{tokcycle}
+\RequirePackage{listofitems}
+
+% Just a shortcut
+\newcommand\ClassErr[1]{%
+  \ClassError{iacrcc}{#1}{}%
+}
+% #1 is a string to check as just text. No macros are allowed except accents
+%    that are easily converted downstream.
+% #2 is an error message prefix.
+\newcommand\checkstring[2]{%
+  % Since tokcycle treats the math toggle character $ as just another character,
+  % we keep track of whether we are in math mode using this if. This allows us
+  % to allow macros and groups in math mode but not in text mode.
+  \newif\ifInMathMode
+  \newif\ifTokenNotFound
+  \tokcycle{% \typeout{CHARACTER: ##1} % character handler.
+            \if##1$% Check if we see a math toggle catcode 3
+              \ifInMathMode % toggle this
+                \InMathModefalse
+              \else
+                \InMathModetrue
+              \fi
+            \fi}% end of character handler
+           {% \typeout{GROUP: ##1}%      group handler
+            \ifInMathMode  % groups are allowed in math mode.
+            \else
+              \ClassErr{#2:^^J group not allowed outside math mode in^^J #1}
+            \fi}% end of group handler
+           {% \typeout{MACRO: \string##1}%  macro handler
+            \ifInMathMode
+              \ClassWarning{iacrcc}{^^JMacros are not recommended in the title^^J}
+            \else
+              \setsepchar{,}% parsing-separator
+              \TokenNotFoundtrue
+              \readlist\phrase{\ ,\$,\#,\&,\%,\ss,\o,\O,\`,\',\^,\",\=,\~,\.,\u,\v,\H,\t,\c,\d,\b,\l,\L,\space,\{,\},\=,\\,\r}%
+              \def\iacrtmp{##1}%
+              \foreachitem\word\in\phrase{%
+                \ifTokenNotFound
+                  \ifx\iacrtmp\word
+                    \TokenNotFoundfalse
+                  \fi
+                \fi
+              }%
+              \ifTokenNotFound
+                \ClassErr{#2:^^Jmacro \iacrtmp not allowed in #1}%
+              \fi
+           \fi
+           }% end of macro handler
+           {% spaces are just ok.
+           }%
+           {#1}% argument to be parsed by tokcycle
+}
+
 % Provide the title of the paper with its various options
 \renewcommand\title[2][]{%
   \IACR@title@params@set@keys{#1}%
@@ -660,10 +723,17 @@ xscale=\@OrigHeightRecip*\@curXheight,transform shape]
   \pgfkeysgetvalue{/IACR-title/entities/running}{\IACR@title@running}%
   \pgfkeysgetvalue{/IACR-title/entities/subtitle}{\IACR@title@subtitle}%
   \pgfkeysgetvalue{/IACR-title/entities/onclick}{\IACR@title@onclick}%
+  \pgfkeysgetvalue{/IACR-title/entities/plaintext}{\IACR@title@plaintext}%
+  \ifx\IACR@title@plaintext\@empty
+    \checkstring{#2}{error in title}
+  \else%
+     \gdef\@plaintitle{\IACR@title@plaintext}%
+     \expandafter\checkstring\expandafter{\IACR@title@plaintext}{plaintext argument to title must be plain text}%
+  \fi
   \if\relax\IACR@title@onclick\relax
-    \gdef\@title{\@plaintitle}%
+    \gdef\@title{#2}%
   \else
-    \gdef\@title{\href{\IACR@title@onclick}{\color{black}{\@plaintitle}}}%
+    \gdef\@title{\href{\IACR@title@onclick}{\color{black}{#2}}}%
   \fi
   \if\relax\IACR@title@running\relax
     \gdef\IACR@title@running{\@plaintitle}%
@@ -949,39 +1019,16 @@ xscale=\@OrigHeightRecip*\@curXheight,transform shape]
 \global\let\IACR@text@keywords\@empty
 \def\IACR@keywords{}
 
-% Macro \ifnotstring is used to check if an argument is just a string.
-% We use it for \keywords but can be useful for other metadata.
-\ExplSyntaxOn
-\prg_generate_conditional_variant:Nnn \tl_if_eq:nn { e } { T,F,TF }
-\cs_new_protected:Npn \onlystring:nn #1#2
-{
-  \tl_if_eq:enTF { \text_purify:n { #1 } } { #1 }
-  {% It's ok, do nothing.
-  }
-  { % raise an error
-    % \PackageError{isstring}{#2 ^^J(#1)}{}
-    #2
-  }
- }
-
-% Usage: \ifnotstring{I'm not text $\mathbb{a}$ so}{execute this}
-\NewDocumentCommand{\ifnotstring}{mm}{\onlystring:nn{#1}{#2}}
-\ExplSyntaxOff
-
 % \IACR@keywords may contain mathematics for display in LaTeX.
 % \IACR@text@keywords is the plain text version used for PDF and metadata.
 
 \newcommand{\keywords}[2][\@empty]{
   \gdef\IACR@keywords{#2}%
   \ifx#1\@empty
-    \ifnotstring{#2}{%
-      \ClassError{iacrcc}{Optional plaintext keyword argument required if keywords contain macros}%
-    }%
+    \checkstring{#2}{Keywords should be free of macros. Use optional argument to \string\keywords}
     \gdef\IACR@text@keywords{#2}%
   \else
-    \ifnotstring{#1}{%
-      \ClassError{iacrcc}{Optional argument to keywords may not contain macros}%
-    }%
+    \checkstring{#1}{optional argument to keywords may not contain macros.}
     \gdef\IACR@text@keywords{#1}%
   \fi
 }

--- a/iacrcc/iacrdoc.tex
+++ b/iacrcc/iacrdoc.tex
@@ -13,13 +13,11 @@
 % <http://creativecommons.org/publicdomain/zero/1.0/>.
 
 \documentclass{iacrcc}
-\usepackage{todonotes}
-
+\usepackage{xcolor}
 \title[running  = {The iacrcc class},
        onclick  = {https://publish.iacr.org/iacrcc},
-       subtitle = {LaTeX Class Documentation (v0.2)},
-      ]
-      {How to Use the IACR Communications in Cryptology Class}
+       subtitle = {LaTeX Class Documentation (v0.24)}
+      ]{How to Use the IACR Communications in Cryptology Class}
 
 \addauthor[orcid   = {0000-0003-1010-8157},
            inst    = {1},
@@ -82,32 +80,27 @@ unnecessary code.
 \begin{itemize}
 \item The production system to which you submit your final version requires
   that the main \LaTeX\ file should be \texttt{main.tex}. You might as
-  well start that way.
-\item The production versions of papers produced with this style will
-  be processed with \texttt{lualatex}.  You can use \texttt{pdflatex}
-  for development, but it lacks modern features for support of UTF-8
-  text and we recommend using \texttt{lualatex} instead.  Do not use
-  any features that are specific to \texttt{pdflatex}, because they
-  will not work in final versions. In particular, do not use the
-  \texttt{fontenc} package; use \texttt{fontspec} instead.
-\item One goal of the \texttt{iacrcc.cls} and \texttt{iacrcc.bst}
-  files is to automate the production of machine-readable metadata in
-  separate files. Users of \LaTeX\ will already be used to seeing this
-  with the \texttt{.log}, \texttt{.aux}, \texttt{.bbl}, \texttt{.blg},
-  \texttt{.toc}, and \texttt{.out} files produced by \texttt{bibtex}
-  and the \texttt{hyperref} package.  You need not be concerned about
-  these, but if your main \LaTeX\ file is called \texttt{main.tex},
-  then the extra files that are produced are:
-\begin{itemize}
-\item a flat text file \texttt{main.meta} containing all metadata
-  from the paper.  When you run \texttt{lualatex} on
-  \texttt{main.tex}, it will produce the metadata from
-  \texttt{main.tex}, and when you run \texttt{bibtex} and
-  \texttt{lualatex} again, it will append the citation data from
-  bibtex into the \texttt{main.meta} file as well.
-\item a file \texttt{main.abstract} that contains
-  the contents of the abstract for the paper.
-\end{itemize}
+  well start that way by copying \texttt{template.tex} to \texttt{main.tex}.
+\item You should use \texttt{lualatex} or \texttt{xelatex} instead of
+  \texttt{pdflatex}. When you submit your final paper, it will be
+  compiled with \texttt{lualatex}. There is a quite good guide to
+  \texttt{lualatex}~\url{http://tug.ctan.org/info/luatex/lualatex-doc/lualatex-doc.pdf}.
+  You can use \texttt{pdflatex} for development, but it lacks modern
+  features for support of UTF-8 text and we recommend using
+  \texttt{lualatex} instead. The final version of your paper must be
+  compiled with \texttt{lualatex}.
+\item Do not change the default fonts; those are chosen by the journal and not you.
+  In particular, do {\color{red}NOT} use the
+  \texttt{fontenc} package; use \texttt{fontspec} instead. If you have
+  to use a non-standard font for some symbols, then only use
+  unicode-encoded fonts ({\color{red}not T1, not T2, and not OT1}).
+\item Avoid using too many packages. Many authors are lazy and just
+  copy what they used in the past. Some won't work - see the list of
+  acceptable packages at \url{https://publish.iacr.org}. Don't use any
+  package that changes fonts. Don't get clever and start writing
+  \texttt{lua} code in your papers.
+\item Don't try to change the \texttt{hyperref} options or the bibliography style.
+\item Don't use macros like \verb+\if+ inside any metadata like the title or abstract.
 \end{itemize}
 \section{Invocation and usage}
 
@@ -123,7 +116,8 @@ The class supports the following class options with \verb+\documentclass{iacrcc}
   requirements.
 \item[\texttt{[biblatex]}] may be used if you prefer using
   \texttt{biblatex} to \texttt{bibtex}. Note that we do not support options to be
-  passed to biblatex, as they may conflict with the style of the journal.
+  passed to biblatex, as they may conflict with the style of the journal. We use
+  a bibliography style based on the alpha style.
 \item[\texttt{[floatrow]}] load the \texttt{floatrow} package. This is useful
   when you have fancy figures or tables. In either case, \texttt{iacrcc}
   will customize how tables and figures are laid out.
@@ -131,7 +125,7 @@ The class supports the following class options with \verb+\documentclass{iacrcc}
 
 Before submitting your final version, please make sure that it compiles
 properly using \texttt{lualatex} with the \texttt{[version=final]} option
-and check that the author names and affiliation are
+and check that the author names and affiliations are
 correct.
 
 The \texttt{iacrcc} class automatically loads \texttt{hyperref}
@@ -148,18 +142,24 @@ A title is added using the \verb+\title+ macro, but with a few other options:
 {\tt running} & The running title displayed in the headers.\\
 {\tt onclick} & Define what to do when clicking on the title. This could be used to point to a webpage associated with this paper. \\
 {\tt subtitle} & Provide a subtitle.\\
+{\tt plaintext} & A text version of the title.\\
 \end{tabular}
 \end{center}
-\noindent  Do not use author-defined macros in arguments to
-\texttt{\textbackslash title}. An example using all the optional
-options would look like:
+\noindent An example using all the optional options would look like:
 
 \begin{verbatim}
 \title[running  = {IACR Communications in Cryptology Class},
        onclick  = {https://github.com/IACR/latex},
-       subtitle = {A Template}
-      ]{How to Use the IACR Communications in Cryptology Class}
+       subtitle = {A Template},
+       plaintext = {How to Use this class}
+      ]{How to Use this class\thanks{Thanks Mom!}}
 \end{verbatim}
+The \verb+plaintext+ version is only required if you use macros in
+your title. Inline mathematics and accents like \verb+\"u+ are allowed
+in plain text, but groups with curly brackets \verb+{...}+ are not
+allowed except within mathematics. \verb+f{\"u}r+ may be written as
+\verb+f\"ur+, but \LaTeX\ has defaulted to UTF-8 input since 2019, so
+just ü is preferred.
 
 \subsection{Footnotes}
 You may use \texttt{\textbackslash{}genericfootnote\{footnotetext\}}
@@ -316,7 +316,7 @@ text-only keywords; for example:
 
 \subsection{Abstract}
 Abstracts are entered with the \texttt{abstract} environment as usual,
-but do not use author-defined macros within the abstract.  Note that
+but do not use macros within the abstract except for inside mathematics.  Note that
 the keywords should be given before starting the abstract
 environment. The \texttt{iacrcc} will automatically produce a file
 \texttt{.abstract} that contains the contents of the abstract.
@@ -344,6 +344,28 @@ symbol at the end of the proof.
 If the QED symbol
 is typeset at a wrong position, you can force its position with
 \verb+\qedhere+.
+
+\section{Auxiliary files}
+One goal of the \texttt{iacrcc.cls} and \texttt{iacrcc.bst}
+  files is to automate the production of machine-readable metadata in
+  separate files. Users of \LaTeX\ will already be used to seeing this
+  with the \texttt{.log}, \texttt{.aux}, \texttt{.bbl}, \texttt{.blg},
+  \texttt{.toc}, and \texttt{.out} files produced by \texttt{bibtex}
+  and the \texttt{hyperref} package.  You need not be concerned about
+  these, but if your main \LaTeX\ file is called \texttt{main.tex},
+  then the extra files that are produced are:
+\begin{itemize}
+\item a flat text file \texttt{main.meta} containing all metadata
+  from the paper.  When you run \texttt{lualatex} on
+  \texttt{main.tex}, it will produce the metadata from
+  \texttt{main.tex}, and when you run \texttt{bibtex} and
+  \texttt{lualatex} again, it will append the citation data from
+  bibtex into the \texttt{main.meta} file as well.
+\item a file \texttt{main.abstract} that contains
+  the contents of the abstract for the paper. This will be used to show
+  the abstract on the web, which is why you should avoid using macros here
+  except in mathematics.
+\end{itemize}
 
 \section{Typesetting the Bibliography}
 \label{sec:biblio}
@@ -413,7 +435,6 @@ We recommend the \texttt{booktabs} package to typeset tables.
 
 We recommend the \texttt{algorithmicx} packages for algorithms (in
 particular, \texttt{algpseudocodex} for pseudo-code).
-
 
 \section{Further information}
 

--- a/iacrcc/parser/test_meta_parse.py
+++ b/iacrcc/parser/test_meta_parse.py
@@ -1,0 +1,16 @@
+import pytest
+from pylatexenc.latex2text import LatexNodes2Text
+from .meta_parse import remove_macros
+
+def test_cleaning():
+    decoder = LatexNodes2Text(math_mode='with-delimiters', keep_braced_groups=False)
+    cases = {r'This has \"umlaut': 'This has ümlaut',
+             r'The title \thanks  {this works}': 'The title',
+             r'This is\\ a long title': 'This is a long title',
+             r'This has the last\index  {foo} part': 'This has the last part',
+             r'We have \r a and \protect \$ for a dollar': 'We have å and $ for a dollar'
+
+             }
+    for input, output in cases.items():
+        print(decoder.latex_to_text(input))
+        assert decoder.latex_to_text(remove_macros(input)) == output

--- a/iacrcc/template.tex
+++ b/iacrcc/template.tex
@@ -120,12 +120,14 @@
 \maketitle
 
 % Provide the keywords *before* the abstract
-%\keywords[Dirac delta function,
-%  unit impulse]{Dirac $\delta$ function,
-%  unit impulse}
+\newcommand{\Dirac}{Dirac}
+\keywords[Dirac delta function,
+  unit impulse]{\Dirac $\delta$ function,
+  unit impulse}
 % Provide the abstract of your paper
 \begin{abstract}
-Abstract goes here.
+  Abstract goes here. You should not use macros inside the abstract, but you
+  may use display mathematics.
 \end{abstract}
 
 % The content of the paper starts here

--- a/iacrcc/tests/compile_tests.py
+++ b/iacrcc/tests/compile_tests.py
@@ -42,7 +42,7 @@ def test1_test():
         assert res['proc'].returncode == 0
         assert 'meta' in res
         meta = meta_parse.parse_meta(res['meta'])
-        assert meta['title'] == "Thoughts about \"binary\" functions on $GF(p)$ by Fester Bestertester at 30\u00b0C"
+        assert meta['title'] == "Thoughts about \"binary\" functions and $ on $GF(p)$ by Fester Bestertester at 30\u00b0C"
         assert len(meta['authors']) == 3
         assert meta['authors'][0]['orcid'] == '0000-0003-1010-8157'
         assert meta['authors'][0]['affiliations'] == ['1','2']
@@ -82,7 +82,7 @@ def test2_test():
         assert affil['postcode'] == '3001'
         assert affil['country'] == 'Belgium'
         assert len(meta['keywords']) == 3
-        assert meta['keywords'][0] == 'Template'
+        assert meta['keywords'][0] == 'Témplate'
         assert meta['keywords'][1] == 'LaTeX'
         assert meta['keywords'][2] == 'IACR'
         assert meta['version'] == 'preprint'
@@ -254,7 +254,7 @@ def test11_test():
         res = run_engine('-pdflua', path.iterdir(), tmpdirpath)
         assert res['proc'].returncode == 0
         meta = meta_parse.parse_meta(res['meta'])
-        assert meta['title'] == 'How not to use the IACR Communications in Cryptology Clåss'
+        assert meta['title'] == 'How not to use the IACR Communications in Cryptology Cláss'
         print(json.dumps(meta,indent=2))
         assert len(meta['keywords']) == 2
         assert meta['keywords'][0] == 'Dirac delta function'
@@ -459,4 +459,5 @@ def test22_test():
         path = Path('test22')
         res = run_engine('-pdflua', path.iterdir(), tmpdirpath)
         assert res['proc'].returncode == 0
-        
+        meta = meta_parse.parse_meta(res['meta'])
+        assert meta['title'] == 'How not to use the IACR Communic̄ations in Cryptology Class'

--- a/iacrcc/tests/test1/main.tex
+++ b/iacrcc/tests/test1/main.tex
@@ -36,8 +36,9 @@
 %%%% 4. TITLE %%%%
 % Note that \thanks and \footnote are forbidden in \title. Please use
 % \genericfootnote.
-\title[running={Thoughts on binary functions}]{Thoughts about
-"binary" functions on $GF(p)$ by \niceguy\ at 30°C}
+\title[running={Thoughts on binary functions},
+  plaintext={Thoughts about "binary" functions and \$\ on $GF(p)$ by Fester Bestertester at 30°C}]{%
+  Thoughts about "binary" functions and \$\ on $GF(p)$ by \niceguy\ at 30°C}
 \begin{document}
 
 \maketitle

--- a/iacrcc/tests/test11/main.tex
+++ b/iacrcc/tests/test11/main.tex
@@ -3,7 +3,7 @@
 \title[running  = {The iacrcc class},
        onclick  = {https://github.com/IACR/latex},
        subtitle = {A Template}
-      ]{How not to use the IACR Communications in Cryptology Cl\r{a}ss}
+      ]{How not to use the IACR Communications in Cryptology Cl\'ass}
 
 \addauthor[orcid    = {0000-0003-1010-8157},
            inst     = {1},

--- a/iacrcc/tests/test14/main.tex
+++ b/iacrcc/tests/test14/main.tex
@@ -3,7 +3,7 @@
 \title[running  = {The iacrcc class},
        onclick  = {https://github.com/IACR/latex},
        subtitle = {A Template}
-      ]{How not to use the IACR Communications in Cryptology Cl\r{a}ss}
+      ]{How not to use the IACR Comm\"unications in Cryptology Class}
 
 \usepackage{lipsum}
 \addauthor[orcid    = {0000-0003-1010-8157},

--- a/iacrcc/tests/test2/main.tex
+++ b/iacrcc/tests/test2/main.tex
@@ -22,7 +22,7 @@
 \title[running  = {The iacrcc class},
        onclick  = {https://github.com/IACR/latex},
        subtitle = {A Template}
-      ]{How to Use the IACR Communications in Cryptology Cl\r{a}ss}
+      ]{How to Use the IACR Communications in Cryptology Cl\r ass}
 
 % Where the options in square brackets “[ ]”are optional and control the following:
 % running: the running title displayed in the headers
@@ -106,7 +106,7 @@
 \maketitle
 
 % Provide the keywords *before* the abstract
-\keywords{Template, LaTeX, IACR}
+\keywords{T\'emplate, LaTeX, IACR}
 
 % Provide the abstract of your paper
 \begin{abstract}

--- a/iacrcc/tests/test22/main.tex
+++ b/iacrcc/tests/test22/main.tex
@@ -5,7 +5,7 @@
 \title[running  = {The iacrcc class},
        onclick  = {https://github.com/IACR/latex},
        subtitle = {A Template}
-      ]{How not to use the IACR Communications in Cryptology Cl\r{a}ss}
+      ]{How not to use the IACR Communi\=cations in Cryptology Class}
 
 \addauthor[orcid    = {0000-0003-1010-8157},
            inst     = {1},


### PR DESCRIPTION
This is a pretty complicated change. One goal is to address #129 The old method of checking for plain text did not allow \" but this version does. Some tests were improved, and some metadata handling was changed. The documentation in iacrdoc.tex was improved.