### PR TITLE
Fix test23 since \thanks is no longer supported.

### DIFF
--- a/iacrcc/tests/compile_tests.py
+++ b/iacrcc/tests/compile_tests.py
@@ -278,6 +278,8 @@ def test11_test():
       assert xmp.get_string('.//prism:publicationName') == 'IACR Communications in Cryptology'
       assert xmp.get_string('.//prism:aggregationType') == 'journal'
       assert xmp.get_string('.//dc:source') == 'main.tex'
+      authors = xmp.get_strings('.//dc:creator/rdf:Seq/rdf:li')
+      assert len(authors) == 2
 
 # TODO: Test12 fails with pdflatex
 # The problem seems to be in:
@@ -1120,14 +1122,12 @@ def test23_test():
       assert line[632] == r"title: Minimal $p$-ary codes from non-covering permutations"
       assert line[633] == r"title: Provable Lattice Reduction of $\protect \mathbb  Z^n$ with Blocksize $n/2$"
       assert line[634] == r"title: Batch Bootstrapping II: \\{\protect \normalsize  Bootstrapping in Polynomial Modulus Only Requires $\protect \tilde  O(1)$ FHE Multiplications in Amortization}"
-      assert line[635] == r"title: Complete Characterization of Broadcast and Pseudo-Signatures from Correlations\protect \thanks  {VN was supported by ISF Grants 1709/14 \protect \textit  {\&} 2774/20 and ERC Project NTSC (742754).}"
-      assert line[636] == r"title: End-to-End Encrypted Zoom Meetings:\\ Proving Security and Strengthening Liveness"
-      assert line[637] == r"title: End-to-End Secure Messaging with Traceability\\ {\protect \em  Only} for Illegal Content"
-      assert line[638] == r"title: \protect \large  {Almost Tight Multi-User Security under Adaptive Corruptions \& Leakages in the Standard Model}"
-      assert line[639] == r"title: Meet-in-the-Middle Preimage Attacks on Sponge-based Hashing\protect \thanks  {The full version of the paper is available at \protect \em  {https://eprint.iacr.org/2022/1714}}"
-      assert line[640] == r"title: Practical Pre-Constrained Cryptography \\ \protect \Large  {(or: Balancing Privacy and Traceability in Encrypted Systems)}"
-      assert line[641] == r"title: \protect \textbf  {Fully Adaptive \\Decentralized Multi-Authority \protect \textsf  {ABE}}"
-      assert line[642] == r"title: On a result by Paul Erdős (a.k.a. Paul Erd\H {o}s)"
+      assert line[635] == r"title: End-to-End Encrypted Zoom Meetings:\\ Proving Security and Strengthening Liveness"
+      assert line[636] == r"title: End-to-End Secure Messaging with Traceability\\ {\protect \em  Only} for Illegal Content"
+      assert line[637] == r"title: \protect \large  {Almost Tight Multi-User Security under Adaptive Corruptions \& Leakages in the Standard Model}"
+      assert line[638] == r"title: Practical Pre-Constrained Cryptography \\ \protect \Large  {(or: Balancing Privacy and Traceability in Encrypted Systems)}"
+      assert line[639] == r"title: \protect \textbf  {Fully Adaptive \\Decentralized Multi-Authority \protect \textsf  {ABE}}"
+      assert line[640] == r"title: On a result by Paul Erdős (a.k.a. Paul Erd\H {o}s)"
 
 # Negative test.
 # Check if we detect using "\thanks" in the author name of the \addauthor command

--- a/iacrcc/tests/test23/main.tex
+++ b/iacrcc/tests/test23/main.tex
@@ -674,11 +674,9 @@
 \def\foo{Minimal $p$-ary codes from non-covering permutations}\@writemeta{title: \foo}
 \def\foo{Provable Lattice Reduction of $\mathbb Z^n$ with Blocksize $n/2$}\@writemeta{title: \foo}
 \def\foo{Batch Bootstrapping II:  \\{\normalsize Bootstrapping in Polynomial Modulus Only Requires $\tilde O(1)$ FHE Multiplications in Amortization}}\@writemeta{title: \foo}
-\def\foo{Complete Characterization of Broadcast and Pseudo-Signatures from Correlations\thanks{VN was supported by ISF Grants 1709/14 \textit{\&} 2774/20 and ERC Project NTSC (742754).}}\@writemeta{title: \foo}
 \def\foo{End-to-End Encrypted Zoom Meetings:\texorpdfstring{\\}{} Proving Security and Strengthening Liveness}\@writemeta{title: \foo}
 \def\foo{End-to-End Secure Messaging with Traceability\\ {\em Only} for Illegal Content}\@writemeta{title: \foo}
 \def\foo{\large{Almost Tight Multi-User Security under Adaptive Corruptions \& Leakages in the Standard Model}}\@writemeta{title: \foo}
-\def\foo{Meet-in-the-Middle Preimage Attacks on Sponge-based Hashing\thanks{The full version of the paper is available at \em{https://eprint.iacr.org/2022/1714}}}\@writemeta{title: \foo}
 \def\foo{Practical Pre-Constrained Cryptography \\ \Large{(or: Balancing Privacy and Traceability in Encrypted Systems)}}\@writemeta{title: \foo}
 \def\foo{\textbf{Fully Adaptive \\Decentralized Multi-Authority \textsf{ABE}}}\@writemeta{title: \foo}
 \def\foo{On a result by Paul Erdős (a.k.a. Paul Erd\H{o}s)}\@writemeta{title: \foo}


### PR DESCRIPTION
We no longer support \thanks in metadata, so this fixes test23.