### PR TITLE
Add crossmark button if \IACR@CROSSMARKURL is defined.

### DIFF
--- a/iacrcc/iacrcc.cls
+++ b/iacrcc/iacrcc.cls
@@ -51,14 +51,9 @@
 \def\IACR@EISSN{}
 \def\IACR@DOI{}
 \def\IACR@CROSSMARKURL{}
-\def\IACR@Received{20XX-XX-XX}
-\def\IACR@Revised{20XX-XX-XX}
-\def\IACR@Accepted{20XX-XX-XX}
-\def\IACR@Published{20XX-XX-XX}
-\newif\if@IACR@Received \@IACR@Receivedfalse
-\newif\if@IACR@Revised \@IACR@Revisedfalse
-\newif\if@IACR@Accepted \@IACR@Acceptedfalse
-\newif\if@IACR@Published \@IACR@Publishedfalse
+\global\let\IACR@Received\@empty
+\global\let\IACR@Accepted\@empty
+\global\let\IACR@Published\@empty
 
 % etoolbox: is a toolbox of programming facilities geared primarily
 %           towards LaTeX class and package authors.
@@ -74,7 +69,7 @@
 % The jobname.iacrmetadata file will contain accepted \IACR@Received,  \IACR@Accepted,
 % \IACR@Published, and \IACR@DOI.
 \InputIfFileExists{\jobname.iacrmetadata}{
-  \@IACR@Receivedtrue\@IACR@Acceptedtrue\@IACR@Publishedtrue\typeout{Inserted DOI into PDF}%
+  \typeout{Inserted DOI into PDF}%
 }{}
 \newif\if@optbiblatex
 \@optbiblatexfalse
@@ -972,10 +967,9 @@
         \hfill{}%
         \doclicenseImage[imagewidth=4em]\\[.1em]%
         \ifcsstring{@IACRversion}{final}{% Only show this information on the final version
-          \if@IACR@Received Received: \IACR@Received \hfill{}\fi%
-          \if@IACR@Revised Revised: \IACR@Revised \hfill{}\fi%
-          \if@IACR@Accepted Accepted: \IACR@Accepted \hfill{}\fi%
-          \if@IACR@Published Published: \IACR@Published\fi%
+          \ifx\IACR@Received\@empty\else Received: \IACR@Received \hfill{}\fi%
+          \ifx\IACR@Accepted\@empty\else Accepted: \IACR@Accepted \hfill{}\fi%
+          \ifx\IACR@Published\@empty\else Published: \IACR@Published\fi%
         }{%
           \ifdefined\@IACR@docdate@defined%
             \ifx\@IACR@docdate\@empty%

--- a/iacrcc/iacrcc.cls
+++ b/iacrcc/iacrcc.cls
@@ -275,11 +275,11 @@
 \definecolor{cffc72c}{RGB}{255,199,44}
 \usepgflibrary{shadings}
 \newcommand\crossmarkimage[1]{%
-\begin{tikzpicture}[scale=#1, every node/.append style={scale=#1}, inner sep=0pt, outer sep=0pt]
+  \begin{tikzpicture}[scale=#1, every node/.append style={scale=#1}, inner sep=0pt, outer sep=0pt]
   \path[draw=c948f8f,top color=white,bottom color=ca0a0a0,fill=cd0d0d0,line width=0.0198cm,miter limit=10.0,rounded corners=0.0529cm] (0.1058, -0.1058) rectangle (7.0, -1.5875);
-  \node[text=c535353,anchor=south west] (text235) at (1.8, -1.15){\fontfamily{phv}\fontseries{sx}\selectfont \LARGE Check for updates};
-  \path[fill=cc72914] (0.6599, -1.1044) -- (1.1393, -0.7848) -- (1.1393, -0.4011) -- (0.6599, -0.4011) -- (0.6599, -1.1044) -- (0.6599, -1.1044)-- cycle;;
-  \path[fill=cef3340] (1.1393, -1.1044) -- (0.6599, -0.7848) -- (0.6599, -0.4011) -- (1.1393, -0.4011) -- (1.1393, -1.1044) -- (1.1393, -1.1044)-- cycle;;
+  \node[text=c535353,anchor=south west] (text235) at (1.8, -1.15){\fontfamily{phv}\selectfont \LARGE Check for updates};
+  \path[fill=cc72914] (0.6599, -1.1044) -- (1.1393, -0.7848) -- (1.1393, -0.4011) -- (0.6599, -0.4011) -- (0.6599, -1.1044) -- (0.6599, -1.1044)-- cycle;
+  \path[fill=cef3340] (1.1393, -1.1044) -- (0.6599, -0.7848) -- (0.6599, -0.4011) -- (1.1393, -0.4011) -- (1.1393, -1.1044) -- (1.1393, -1.1044)-- cycle;
   \path[fill=c3eb1c8] (0.8996, -0.3175)arc(90.0:360.0:0.5292)arc(0.0:90.0:0.5292) -- cycle(0.8996, -1.2462)arc(270.0:0.0:0.3995)arc(0.0:-90.0:0.3995) -- cycle;
   \path[fill=cffc72c] (1.193, -1.1173)arc(317.2441:158.1926:0.3993) -- (0.418, -0.6281)arc(155.807:319.67:0.5292) -- cycle;
 \end{tikzpicture}}
@@ -485,10 +485,12 @@
     \global\let\date\relax
     \global\let\and\relax
     % Adjust header size for title page
-    \addtolength{\headheight}{\baselineskip}%
+    \ifx\IACR@CROSSMARKURL\@empty\addtolength{\headheight}{\baselineskip}\else%
+       \addtolength{\headheight}{2\baselineskip}\fi%
     \addtolength{\headsep}{-\baselineskip}%
     \afterpage{%
-      \global\advance\headheight by -\baselineskip%
+     \ifx\IACR@CROSSMARKURL\@empty\global\advance\headheight by -\baselineskip\else%
+         \global\advance\headheight by -2\baselineskip\fi
       \global\advance\headsep by \baselineskip%
     }%
   }%

--- a/iacrcc/iacrcc.cls
+++ b/iacrcc/iacrcc.cls
@@ -273,10 +273,9 @@
 \definecolor{cef3340}{RGB}{239,51,64}
 \definecolor{c3eb1c8}{RGB}{62,177,200}
 \definecolor{cffc72c}{RGB}{255,199,44}
-\usepgflibrary{shadings}
 \newcommand\crossmarkimage[1]{%
   \begin{tikzpicture}[scale=#1, every node/.append style={scale=#1}, inner sep=0pt, outer sep=0pt]
-  \path[draw=c948f8f,top color=white,bottom color=ca0a0a0,fill=cd0d0d0,line width=0.0198cm,miter limit=10.0,rounded corners=0.0529cm] (0.1058, -0.1058) rectangle (7.0, -1.5875);
+  \path[draw=c948f8f,shading=axis,top color=white,bottom color=ca0a0a0,fill=cd0d0d0,line width=0.0198cm,miter limit=10.0,rounded corners=0.0529cm] (0.1058, -0.1058) rectangle (7.0, -1.5875);
   \node[text=c535353,anchor=south west] (text235) at (1.8, -1.15){\fontfamily{phv}\selectfont \LARGE Check for updates};
   \path[fill=cc72914] (0.6599, -1.1044) -- (1.1393, -0.7848) -- (1.1393, -0.4011) -- (0.6599, -0.4011) -- (0.6599, -1.1044) -- (0.6599, -1.1044)-- cycle;
   \path[fill=cef3340] (1.1393, -1.1044) -- (0.6599, -0.7848) -- (0.6599, -0.4011) -- (1.1393, -0.4011) -- (1.1393, -1.1044) -- (1.1393, -1.1044)-- cycle;

--- a/iacrcc/iacrcc.cls
+++ b/iacrcc/iacrcc.cls
@@ -50,6 +50,7 @@
 \def\IACR@fp{1}
 \def\IACR@EISSN{}
 \def\IACR@DOI{}
+\def\IACR@CROSSMARKURL{}
 \def\IACR@Received{20XX-XX-XX}
 \def\IACR@Revised{20XX-XX-XX}
 \def\IACR@Accepted{20XX-XX-XX}
@@ -263,6 +264,26 @@
 % End of macros for orcidlink
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
+% Macro for crossmark image.
+\definecolor{c948f8f}{RGB}{148,143,143}
+\definecolor{cd0d0d0}{RGB}{208,208,208}
+\definecolor{ca0a0a0}{RGB}{192,192,192}
+\definecolor{c535353}{RGB}{83,83,83}
+\definecolor{cc72914}{RGB}{199,41,20}
+\definecolor{cef3340}{RGB}{239,51,64}
+\definecolor{c3eb1c8}{RGB}{62,177,200}
+\definecolor{cffc72c}{RGB}{255,199,44}
+\usepgflibrary{shadings}
+\newcommand\crossmarkimage[1]{%
+\begin{tikzpicture}[scale=#1, every node/.append style={scale=#1}, inner sep=0pt, outer sep=0pt]
+  \path[draw=c948f8f,top color=white,bottom color=ca0a0a0,fill=cd0d0d0,line width=0.0198cm,miter limit=10.0,rounded corners=0.0529cm] (0.1058, -0.1058) rectangle (7.0, -1.5875);
+  \node[text=c535353,anchor=south west] (text235) at (1.8, -1.15){\fontfamily{phv}\fontseries{sx}\selectfont \LARGE Check for updates};
+  \path[fill=cc72914] (0.6599, -1.1044) -- (1.1393, -0.7848) -- (1.1393, -0.4011) -- (0.6599, -0.4011) -- (0.6599, -1.1044) -- (0.6599, -1.1044)-- cycle;;
+  \path[fill=cef3340] (1.1393, -1.1044) -- (0.6599, -0.7848) -- (0.6599, -0.4011) -- (1.1393, -0.4011) -- (1.1393, -1.1044) -- (1.1393, -1.1044)-- cycle;;
+  \path[fill=c3eb1c8] (0.8996, -0.3175)arc(90.0:360.0:0.5292)arc(0.0:90.0:0.5292) -- cycle(0.8996, -1.2462)arc(270.0:0.0:0.3995)arc(0.0:-90.0:0.3995) -- cycle;
+  \path[fill=cffc72c] (1.193, -1.1173)arc(317.2441:158.1926:0.3993) -- (0.418, -0.6281)arc(155.807:319.67:0.5292) -- cycle;
+\end{tikzpicture}}
+% end of crossmark image
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % This produces an icon for an external link. We use it as the external link
 % icon for onclick on authors.
@@ -936,9 +957,10 @@
         \small%
         \publname{}\\
         \ifx\IACR@EISSN\@empty\else{ISSN~\IACR@EISSN, }\fi%
-        Vol.~\IACR@vol, No.~\IACR@no, \IACR@lp\ pages.%
-        \ifx\IACR@DOI\@empty\else\hfill{}\href{https://doi.org/\IACR@DOI}{https://doi.org/\IACR@DOI}\fi%
-      }
+        Vol.~\IACR@vol, No.~\IACR@no, \IACR@lp\ pages.}
+      \ifx\IACR@DOI\@empty\else\fancyhead[R]{\small%
+        \begin{tabular}{r}\href{https://doi.org/\IACR@DOI}{https://doi.org/\IACR@DOI}\ifx\IACR@CROSSMARKURL\@empty\else\vspace{2px}\\%
+        \href{\IACR@CROSSMARKURL}{\crossmarkimage{.35}}\fi\end{tabular}}\fi%
   }{}% final
   \ifx\@IACR@License\@empty\else%
     % If \license is provided show this for preprint and final (not for submission)


### PR DESCRIPTION
If `\IACR@CROSSMARKURL` is defined, then it shows a crossmark button. The `\IACR@CROSSMARKURL` should have the format shown by the [crossmark documentation](https://www.crossref.org/documentation/crossmark/participating-in-crossmark/)
```
https://crossmark.crossref.org/dialog/?doi=10.5555/12345678&amp;domain=pdf&amp;date_stamp=2008-08-14
```
I plan to put the following into the `main.iacrmetadata` file:
```
\def\IACR@DOI{10.62056/aptwalk}
\def\IACR@Published{2024-02-03}
\def\IACR@CROSSMARKURL{https://crossmark.crossref.org/dialog/?doi={\IACR@DOI}\&domain=pdf\&date\_stamp={\IACR@Published}}
```
There are several things that we might consider changing:
1. the size of the image
2. the position of the image
3. the url can actually omit the date_stamp.

I've attached a sample:
[iacrdoc.pdf](https://github.com/IACR/latex/files/14257751/iacrdoc.pdf)
