### PR TITLE
Fix biblatex shorthands

### DIFF
--- a/iacrcc/iacrcc.cls
+++ b/iacrcc/iacrcc.cls
@@ -999,6 +999,7 @@
   \DeclarePrintbibliographyDefaults{heading=bibintoc}%
   \DeclareLabelalphaTemplate{
     \labelelement{
+      \field[final]{shorthand}
       \field[strwidth=3,strside=left]{label}
       \field[strwidth=3,strside=left,ifnames=1]{labelname}
       \field[strwidth=1,strside=left]{labelname}


### PR DESCRIPTION
This fix is taken from an example in the biblatex manual, search for `\field[final]{shorthand}`.

See also https://github.com/IACR/latex/issues/253 for context.